### PR TITLE
Add test_success job to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,3 +23,8 @@ jobs:
         run: |
           poetry install
           poetry run make test_all
+  test_success:
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+    - run: echo Success!


### PR DESCRIPTION
Somehow the branch protection rules don't recognize that `test` is an aggregate of the cartesian join of os+python version matrices tested, so add a `test_success` job that depends on `test`, then edit the branch rules